### PR TITLE
Allow config of :pg_system_user for non-standard installs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ yet another fricking password.<br/>
 `pg_password` option has precedence. If it is set,
 `pg_ask_for_password` is ignored.
 
+* `set :pg_system_user`<br/>
+Default `postgres`. Set this option to the user that owns the postgres process
+on your system. Normally the default is fine, but for instance on FreeBSD the
+default prostgres user is `pgsql`.
+
 `database.yml` template-only settings:
 
 * `set :pg_pool`<br/>

--- a/lib/capistrano/postgresql/psql_helpers.rb
+++ b/lib/capistrano/postgresql/psql_helpers.rb
@@ -4,7 +4,7 @@ module Capistrano
 
       # returns true or false depending on the remote command exit status
       def psql(*args)
-        test :sudo, '-u postgres psql', *args
+        test :sudo, "-u #{fetch(:pg_system_user)} psql", *args
       end
 
       def db_user_exists?(name)

--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -12,6 +12,7 @@ namespace :load do
     set :pg_user, -> { fetch(:pg_database) }
     set :pg_ask_for_password, false
     set :pg_password, -> { ask_for_or_generate_password }
+    set :pg_system_user, 'postgres'
     # template only settings
     set :pg_templates_path, 'config/deploy/templates'
     set :pg_pool, 5


### PR DESCRIPTION
On FreeBSD postgres is owned by the `pgsql` user, so we need to be
able to configure which user is ised by the psql-helper.
