### PR TITLE
Be explicit about working on the system database.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Default `postgres`. Set this option to the user that owns the postgres process
 on your system. Normally the default is fine, but for instance on FreeBSD the
 default prostgres user is `pgsql`.
 
+* `set :pg_system_db`<br/>
+Default `postgres`. Set this if the system database don't have the standard name.
+Usually there should be no reason to change this from the default.
+
 `database.yml` template-only settings:
 
 * `set :pg_pool`<br/>

--- a/lib/capistrano/postgresql/psql_helpers.rb
+++ b/lib/capistrano/postgresql/psql_helpers.rb
@@ -4,7 +4,7 @@ module Capistrano
 
       # returns true or false depending on the remote command exit status
       def psql(*args)
-        test :sudo, "-u #{fetch(:pg_system_user)} psql", *args
+        test :sudo, "-u #{fetch(:pg_system_user)} psql -d #{fetch(:pg_system_db)}", *args
       end
 
       def db_user_exists?(name)

--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -13,6 +13,7 @@ namespace :load do
     set :pg_ask_for_password, false
     set :pg_password, -> { ask_for_or_generate_password }
     set :pg_system_user, 'postgres'
+    set :pg_system_db, 'postgres'
     # template only settings
     set :pg_templates_path, 'config/deploy/templates'
     set :pg_pool, 5


### PR DESCRIPTION
When using a non-standard pg_system_user psql assumes you want
to access a database with the same name as the user, unless you
specify explicitly. This database should normally be calles
'postgres', but in case someone has a really weird setup I made
it configurable.
