### PR TITLE
Added migration_role as node that needs database.yml

### DIFF
--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -26,7 +26,7 @@ namespace :postgresql do
 
   # undocumented, for a reason: drops database. Use with care!
   task :remove_all do
-    on roles :app do
+    on roles [:app, fetch(:migration_role)] do
       if test "[ -e #{database_yml_file} ]"
         execute :rm, database_yml_file
       end
@@ -61,7 +61,7 @@ namespace :postgresql do
 
   desc 'Generate database.yml'
   task :generate_database_yml do
-    on roles :app do
+    on roles [:app, fetch(:migration_role)] do
       next if test "[ -e #{database_yml_file} ]"
       execute :mkdir, '-pv', shared_path.join('config')
       upload! pg_template('postgresql.yml.erb'), database_yml_file


### PR DESCRIPTION
The node that runs the migrations might not be an app node. For example
a dedicated db node that runs its own migrations needs the Ruby code
and database.yml. In migrations.rake of capistrano-rails, the migrations
can be run on a role specified by the migration_role. This edit is to
ensure that if the migration_role is different from app, that node run
the migrations and connect to the db using database.yml settings.
