### PR TITLE
Changed to release_roles :all as roles that needs database.yml

### DIFF
--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -26,7 +26,7 @@ namespace :postgresql do
 
   # undocumented, for a reason: drops database. Use with care!
   task :remove_all do
-    on roles :app do
+    on release_roles :all do
       if test "[ -e #{database_yml_file} ]"
         execute :rm, database_yml_file
       end
@@ -61,7 +61,7 @@ namespace :postgresql do
 
   desc 'Generate database.yml'
   task :generate_database_yml do
-    on roles :app do
+    on release_roles :all do
       next if test "[ -e #{database_yml_file} ]"
       execute :mkdir, '-pv', shared_path.join('config')
       upload! pg_template('postgresql.yml.erb'), database_yml_file


### PR DESCRIPTION
Other roles besides :app need to be able to access the database. For
example, a dedicated db node that runs its own migrations but does not have
the :app role needs the Ruby code and database.yml. In migrations.rake of
capistrano-rails, the migrations can be run on a role specified by the
migration_role.

This commit is to ensure that all release_roles have a copy of database.yml
on setup, in order that they can connect to the database.
