### PR TITLE
Ensure database.yml on newly created clients has correct credentials. fixes #5

### DIFF
--- a/lib/capistrano/postgresql/helper_methods.rb
+++ b/lib/capistrano/postgresql/helper_methods.rb
@@ -15,10 +15,16 @@ module Capistrano
         StringIO.new ERB.new(File.read(config_file)).result(binding)
       end
 
+      # location of database.yml file on clients
       def database_yml_file
         shared_path.join('config/database.yml')
       end
 
+      # location of archetypical database.yml file created on primary db role when user and
+      # database are first created
+      def archetype_database_yml_file
+        deploy_path.join("db/database.yml")
+      end
     end
   end
 end


### PR DESCRIPTION
This commit changes the way in which database.yml is created. Previously, a randomly
generated password would be created on database set up, but also when a client
does not have the database.yml file. If a new client if created after the db,
it gets a database.yml file with a newly generated random - and incorrect -
password.

In this commit, when the db and db-user are first created, an archetype
database.yml file is created on the primary db role with the credentials
for the db. This is subsequently copied on every setup to all clients, so
newly created clients now also get the right credentials for connecting
to the db.
