### PR TITLE
Added optional addition of hstore extension to db

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ creates database for your app.
 * `postgresql:generate_database_yml`<br/>
 creates a `database.yml` file and copies it to
 `#{shared_path}/config/database.yml` on the server.
+* `postgresql:add_hstore`<br/>
+creates the hstore extension for your application database. This task only runs
+if `:pg_use_hstore` is set to true (see below).
 
 Also, the plugin ensures `config/database.yml` is symlinked from `shared_path`.
 The above tasks are all you need for getting a Rails app to work with PostgreSQL.
@@ -118,6 +121,10 @@ default prostgres user is `pgsql`.
 * `set :pg_system_db`<br/>
 Default `postgres`. Set this if the system database don't have the standard name.
 Usually there should be no reason to change this from the default.
+
+* `set :pg_use_hstore`<br/>
+Default `false`. If true, the `postgresql:add_hstore` task is executed and the hstore extension 
+is added to `:pg_database`.
 
 `database.yml` template-only settings:
 

--- a/lib/capistrano/postgresql/psql_helpers.rb
+++ b/lib/capistrano/postgresql/psql_helpers.rb
@@ -4,7 +4,12 @@ module Capistrano
 
       # returns true or false depending on the remote command exit status
       def psql(*args)
-        test :sudo, "-u #{fetch(:pg_system_user)} psql -d #{fetch(:pg_system_db)}", *args
+        psql_on_db(fetch(:pg_system_db), *args)
+      end
+
+      # Runs psql on the application database
+      def psql_on_app_db(*args)
+        psql_on_db(fetch(:pg_database), *args)
       end
 
       def db_user_exists?(name)
@@ -15,6 +20,10 @@ module Capistrano
         psql '-tAc', %Q{"SELECT 1 FROM pg_database WHERE datname='#{db_name}';" | grep -q 1}
       end
 
+      private
+      def psql_on_db(db_name, *args)
+        test :sudo, "-u #{fetch(:pg_system_user)} psql -d #{db_name}", *args
+      end
     end
   end
 end

--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -14,6 +14,7 @@ namespace :load do
     set :pg_password, -> { ask_for_or_generate_password }
     set :pg_system_user, 'postgres'
     set :pg_system_db, 'postgres'
+    set :pg_use_hstore, false
     # template only settings
     set :pg_templates_path, 'config/deploy/templates'
     set :pg_pool, 5
@@ -41,6 +42,14 @@ namespace :postgresql do
     on roles :db do
       psql '-c', %Q{"DROP database #{fetch(:pg_database)};"}
       psql '-c', %Q{"DROP user #{fetch(:pg_user)};"}
+    end
+  end
+
+  desc "Add the hstore extension to postgresql"
+  task :add_hstore do
+    next unless fetch(:pg_use_hstore)
+    on roles :db do
+      psql_on_app_db '-c', %Q{"CREATE EXTENSION IF NOT EXISTS hstore;"}
     end
   end
 
@@ -102,6 +111,7 @@ namespace :postgresql do
   task :setup do
     invoke "postgresql:create_db_user"
     invoke "postgresql:create_database"
+    invoke 'postgresql:add_hstore'
     invoke "postgresql:generate_database_yml_archetype"
     invoke "postgresql:generate_database_yml"
   end


### PR DESCRIPTION
This PR adds a new task `postgresql:add_hstore` which adds the hstore extension to the application DB. Note that a new `psql_on_app_db` command had to be introduced for this, because simply calling `psql '-c', %Q{"CREATE EXTENSION IF NOT EXISTS hstore;"}` would have created the hstore extension the `:pg_system_db`.
