### PR TITLE
Take `rails_env` option into consideration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
+# Changelog
+
+### master
+- enable setting DB environment with `rails_env` option. If `rails_env` is not
+  set, `stage` option is used as until now. (@bruno-)
+
 ### v3.0.0, 2014-04-11
 - all the work is moved to the `setup` task
+
 ### v2.0.0, 2014-03-30
 - shorten variable names: postgresql -> pg
 - better helpers module separation
@@ -7,5 +14,6 @@
 - lots of code improvements
 - less layered and simpler code
 - readme updates
+
 ### v1.0.0, 2014-03-19
 - all the v1.0.0 features

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ process:
 Put the following in your application's `Gemfile`:
 
     group :development do
-      gem 'capistrano', '~> 3.1'
+      gem 'capistrano', '~> 3.2.0'
       gem 'capistrano-postgresql', '~> 3.0'
     end
 
@@ -128,6 +128,10 @@ is added to `:pg_database`.
 
 `database.yml` template-only settings:
 
+* `set :pg_env`<br/>
+DB environment. Defaults to the value of `rails_env` option. If `rails_env` is
+not set, it defaults to `stage` option.
+
 * `set :pg_pool`<br/>
 Pool config in `database.yml` template. Defaults to `5`.
 
@@ -143,7 +147,7 @@ This is the default `database.yml` template that gets copied to the capistrano
 shared directory on the server:
 
 ```yml
-<%= fetch :stage %>:
+<%= fetch :pg_env %>:
   adapter: postgresql
   encoding: <%= pg_encoding %>
   database: <%= pg_database %>

--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -17,6 +17,7 @@ namespace :load do
     set :pg_use_hstore, false
     # template only settings
     set :pg_templates_path, 'config/deploy/templates'
+    set :pg_env, -> { fetch(:rails_env) || fetch(:stage) }
     set :pg_pool, 5
     set :pg_encoding, 'unicode'
     set :pg_host, 'localhost'

--- a/lib/generators/capistrano/postgresql/templates/postgresql.yml.erb
+++ b/lib/generators/capistrano/postgresql/templates/postgresql.yml.erb
@@ -1,4 +1,4 @@
-<%= fetch :stage %>:
+<%= fetch :pg_env %>:
   adapter: postgresql
   encoding: <%= fetch :pg_encoding %>
   database: <%= fetch :pg_database %>


### PR DESCRIPTION
This change splits the direct connection between a `stage` option and DB
environment.

A user might have a stage file example: `config/deploy/staging_new.rb` With
this, `stage` variable is set to `staging_new` which makes no sense.

With this update a user can:
- set the stage with `rails_env` option. This is convenient and "just
  works" if capistrano-rails gem is used.
- set the DB env explicitly with `pg_env` option. This one should not be
  necessary though.

Lastly, this change is "backwards compatible", meaning - without extra options
everything will work as until now.
