### PR TITLE
Automatically set proper pg_host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ### master
+- automatically set `pg_host` option to the IP address of primary `db` host when
+  there are multiple release nodes (@bruno-)
 
 ### v4.0.0, 2014-10-06
 - enable setting DB environment with `rails_env` option. If `rails_env` is not

--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -20,7 +20,15 @@ namespace :load do
     set :pg_env, -> { fetch(:rails_env) || fetch(:stage) }
     set :pg_pool, 5
     set :pg_encoding, 'unicode'
-    set :pg_host, 'localhost'
+    # for multiple release nodes automatically use server hostname (IP?) in the database.yml
+    set :pg_host, -> do
+      if release_roles(:all).count == 1 && release_roles(:all).first == primary(:db)
+        'localhost'
+      else
+        primary(:db).hostname
+      end
+    end
+
   end
 end
 


### PR DESCRIPTION
For a setup with multiple release nodes database.yml should contain the IP of the database server (not string 'localhost').
