### PR TITLE
Use psql_simple in creation of db user

### DIFF
--- a/lib/capistrano/postgresql/psql_helpers.rb
+++ b/lib/capistrano/postgresql/psql_helpers.rb
@@ -21,10 +21,13 @@ module Capistrano
       end
 
       private
+      def psql_simple(*args)
+        test :sudo, "-u #{fetch(:pg_system_user)} psql", *args
+      end
+
       def psql_on_db(db_name, *args)
         test :sudo, "-u #{fetch(:pg_system_user)} psql -d #{db_name}", *args
       end
     end
   end
 end
-

--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -97,7 +97,7 @@ namespace :postgresql do
   task :create_db_user do
     on roles :db do
       next if db_user_exists? fetch(:pg_user)
-      unless psql '-c', %Q{"CREATE user #{fetch(:pg_user)} WITH password '#{fetch(:pg_password)}';"}
+      unless psql_simple '-c', %Q{"CREATE user #{fetch(:pg_user)} WITH password '#{fetch(:pg_password)}';"}
         error 'postgresql: creating database user failed!'
         exit 1
       end


### PR DESCRIPTION
Creates a new function that call psql without the database parameter.
This fixes the issue when creating a db user without the existence of the set database.
See #31.
