### PR TITLE
Resolved issues / 4.3.0 bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Or just install
 [capistrano-safe-deploy-to](https://github.com/capistrano-plugins/capistrano-safe-deploy-to)
 plugin and don't think about it.
 
+Within your app/config/deploy/#{environment}.rb files, make sure to specify:
+
+    set :system_user, 'ssh_user' # defaults to root user
+
 To setup the server(s), run:
 
     $ bundle exec cap production setup

--- a/lib/capistrano/postgresql/helper_methods.rb
+++ b/lib/capistrano/postgresql/helper_methods.rb
@@ -17,13 +17,15 @@ module Capistrano
 
       # location of database.yml file on clients
       def database_yml_file
+        raise(":deploy_to in your app/config/deploy/\#{environment}.rb file cannot contain ~") if shared_path.to_s.include?('~') # issues/27
         shared_path.join('config/database.yml')
       end
 
       # location of archetypical database.yml file created on primary db role when user and
       # database are first created
       def archetype_database_yml_file
-        deploy_path.join("db/database.yml")
+        raise(":deploy_to in your app/config/deploy/\#{environment}.rb file cannot contain ~") if shared_path.to_s.include?('~') # issues/27
+        deploy_path.join('db/database.yml')
       end
     end
   end

--- a/lib/capistrano/postgresql/psql_helpers.rb
+++ b/lib/capistrano/postgresql/psql_helpers.rb
@@ -21,6 +21,11 @@ module Capistrano
       end
 
       private
+
+      def psql_simple(*args)
+        test :sudo, "-u #{fetch(:pg_system_user)} psql", *args
+      end
+
       def psql_on_db(db_name, *args)
         test :sudo, "-u #{fetch(:pg_system_user)} psql -d #{db_name}", *args
       end

--- a/lib/capistrano/postgresql/version.rb
+++ b/lib/capistrano/postgresql/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Postgresql
-    VERSION = "4.2.1"
+    VERSION = "4.3.0"
   end
 end

--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -140,7 +140,7 @@ namespace :postgresql do
 
     on release_roles :all do
       execute :mkdir, '-pv', File.dirname(database_yml_file)
-      Net::SCP.upload!(fetch(:pg_host), fetch(:system_user), StringIO.new(database_yml_contents), database_yml_file)
+      Net::SCP.upload!(self.host.hostname, fetch(:system_user), StringIO.new(database_yml_contents), database_yml_file)
     end
   end
 


### PR DESCRIPTION
Fixed issues/31: psql -> psql_simple so user can be created regardless of database existence.

Preventing issues/27: Added raise if :deploy_to path has ~ (SCP doesn't like it)

Switched upload! to Net::SCP.upload! so we can use new :system_user to specify the deployment ssh user we want. Added readme requirement.

General cleanup of quotes to follow Ruby convention.

Version bump.