### PR TITLE
V4.4.0: database.yml cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+Gemfile.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 Gemfile.lock
+*.gem

--- a/lib/capistrano/postgresql/version.rb
+++ b/lib/capistrano/postgresql/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Postgresql
-    VERSION = "4.3.1"
+    VERSION = "4.4.0"
   end
 end


### PR DESCRIPTION
I noticed that app role servers don't update their database.yml when I run cap staging/production setup. Added new task to handle removing all files before regenerating them with your new settings. Confirmed it's working great.