### PR TITLE
issues/22 : Make sudo optional

### DIFF
--- a/lib/capistrano/postgresql/psql_helpers.rb
+++ b/lib/capistrano/postgresql/psql_helpers.rb
@@ -4,6 +4,7 @@ module Capistrano
 
       # returns true or false depending on the remote command exit status
       def psql(*args)
+        args.unshift("-U #{fetch(:pg_system_user)}") if fetch(:pg_no_sudo)
         psql_on_db(fetch(:pg_system_db), *args)
       end
 

--- a/lib/capistrano/postgresql/psql_helpers.rb
+++ b/lib/capistrano/postgresql/psql_helpers.rb
@@ -27,7 +27,10 @@ module Capistrano
       end
 
       def psql_on_db(db_name, *args)
-        test :sudo, "-u #{fetch(:pg_system_user)} psql -d #{db_name}", *args
+        cmd = [ :psql, "-d #{db_name}", *args ]
+        cmd = [ :sudo, "-u #{fetch(:pg_system_user)}", *cmd ] unless fetch(:pg_no_sudo)
+        test *cmd.flatten
+        #test :sudo, "-u #{fetch(:pg_system_user)} psql -d #{db_name}", *args
       end
     end
   end

--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -16,6 +16,7 @@ namespace :load do
     set :pg_system_db, 'postgres'
     set :pg_use_hstore, false
     set :pg_extensions, []
+    set :pg_no_sudo, false
     # template only settings
     set :pg_templates_path, 'config/deploy/templates'
     set :pg_env, -> { fetch(:rails_env) || fetch(:stage) }


### PR DESCRIPTION
Allow deploying to setups where sudo is not available or undesireable.

Add `set :pg_no_sudo, true` do disable using sudo.

I've been using this branch for a while myself, but rebased it to make a clean merge. I advice testing that it does not break common existing setups before merging. Let me know if there's anything else I should fix before merging.