### PR TITLE
remove `pry` from code

### DIFF
--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -2,8 +2,6 @@ require 'capistrano/postgresql/helper_methods'
 require 'capistrano/postgresql/password_helpers'
 require 'capistrano/postgresql/psql_helpers'
 
-require 'pry'
-
 include Capistrano::Postgresql::HelperMethods
 include Capistrano::Postgresql::PasswordHelpers
 include Capistrano::Postgresql::PsqlHelpers


### PR DESCRIPTION
capistrano-postgresql shoud not add dependency to debugger tools

Fixes https://github.com/capistrano-plugins/capistrano-postgresql/issues/42

TODO: Remember to publish a new release after fixing.