### PR TITLE
Adding port setting to net scp uploader

### DIFF
--- a/lib/capistrano/tasks/postgresql.rake
+++ b/lib/capistrano/tasks/postgresql.rake
@@ -110,10 +110,10 @@ namespace :postgresql do
   task :generate_database_yml_archetype do
     on primary :db do
       if test "[ -e #{archetype_database_yml_file} ]" # Archetype already exists. Just update values that changed. Make sure we don't overwrite it to protect generated passwords.
-        Net::SCP.upload!(self.host.hostname, self.host.user,StringIO.new(pg_template(true, download!(archetype_database_yml_file))),archetype_database_yml_file)
+        Net::SCP.upload!(self.host.hostname, self.host.user, StringIO.new(pg_template(true, download!(archetype_database_yml_file))), archetype_database_yml_file, ssh: { port: self.host.port })
       else
         execute :mkdir, '-pv', File.dirname(archetype_database_yml_file)
-        Net::SCP.upload!(self.host.hostname,self.host.user,StringIO.new(pg_template),archetype_database_yml_file)
+        Net::SCP.upload!(self.host.hostname, self.host.user, StringIO.new(pg_template), archetype_database_yml_file, ssh: { port: self.host.port })
       end
     end
   end
@@ -127,7 +127,7 @@ namespace :postgresql do
     end
     on release_roles :all do
       execute :mkdir, '-pv', File.dirname(database_yml_file)
-      Net::SCP.upload!(self.host.hostname, self.host.user, StringIO.new(database_yml_contents), database_yml_file)
+      Net::SCP.upload!(self.host.hostname, self.host.user, StringIO.new(database_yml_contents), database_yml_file, ssh: { port: self.host.port })
     end
   end
 


### PR DESCRIPTION
I was running `bundle exec cap stage_name setup` and found that the library could not perform any actions because of my not standard SSH port setup.

`SSHKit::Runner::ExecuteError: Exception while executing as xxxx@123.123.123.123: Connection refused - connect(2) for 123.123.123.123:22`

This PR fixes the issue.

Remember to setup your super cool port number in the server configuration:
```ruby
server '123.123.123.123', user: 'xxxx', roles: %w{web app db}, port: 123, my_property: :my_value
```

At least for me, SSHKit was not picking up the `ssh_options` config:
```ruby
set :ssh_options, {
  forward_agent: true,
  port: 123
}
```
Maybe this changes in Capistrano and I'm not aware?

I tested my patch without any port specified and worked just fine. It tried the default 22 port number.
```ruby
server '123.123.123.123', user: 'xxxx', roles: %w{web app db}, my_property: :my_value
```
