### PR TITLE
Support for non-default pg_port

### DIFF
--- a/lib/capistrano/postgresql/helper_methods.rb
+++ b/lib/capistrano/postgresql/helper_methods.rb
@@ -5,7 +5,7 @@ module Capistrano
     module HelperMethods
 
       def extension_exists?(extension)
-        psql 'test', fetch(:pg_database), '-tAc', %Q{"SELECT 1 FROM pg_extension WHERE extname='#{extension}';" | grep -q 1}
+        psql 'test', fetch(:pg_database), "-p #{fetch(:pg_port)} -tAc", %Q{"SELECT 1 FROM pg_extension WHERE extname='#{extension}';" | grep -q 1}
       end
 
       def remove_extensions
@@ -14,7 +14,7 @@ module Capistrano
             # remove in reverse order if extension is present
             Array( fetch(:pg_extensions) ).reverse.each do |ext|
               next if [nil, false, ""].include?(ext)
-              psql 'execute', fetch(:pg_database), '-c', %Q{"DROP EXTENSION IF EXISTS #{ext};"} if extension_exists?(ext)
+              psql 'execute', fetch(:pg_database), "-p #{fetch(:pg_port)} -c", %Q{"DROP EXTENSION IF EXISTS #{ext};"} if extension_exists?(ext)
             end
           end
         end

--- a/lib/capistrano/postgresql/psql_helpers.rb
+++ b/lib/capistrano/postgresql/psql_helpers.rb
@@ -20,17 +20,17 @@ module Capistrano
       end
 
       def database_user_exists?
-        psql 'test', fetch(:pg_system_db),'-tAc', %Q{"SELECT 1 FROM pg_roles WHERE rolname='#{fetch(:pg_username)}';" | grep -q 1}
+        psql 'test', fetch(:pg_system_db),"-p #{fetch(:pg_port)} -tAc", %Q{"SELECT 1 FROM pg_roles WHERE rolname='#{fetch(:pg_username)}';" | grep -q 1}
       end
 
       def database_user_password_different?
-        current_password_md5 = psql 'capture', fetch(:pg_system_db),'-tAc', %Q{"select passwd from pg_shadow WHERE usename='#{fetch(:pg_username)}';"}
+        current_password_md5 = psql 'capture', fetch(:pg_system_db),"-p #{fetch(:pg_port)} -tAc", %Q{"select passwd from pg_shadow WHERE usename='#{fetch(:pg_username)}';"}
         new_password_md5 = "md5#{Digest::MD5.hexdigest("#{fetch(:pg_password)}#{fetch(:pg_username)}")}"
         current_password_md5 == new_password_md5 ? false : true
       end
 
       def database_exists?
-        psql 'test', fetch(:pg_system_db), '-tAc', %Q{"SELECT 1 FROM pg_database WHERE datname='#{fetch(:pg_database)}';" | grep -q 1}
+        psql 'test', fetch(:pg_system_db), "-p #{fetch(:pg_port)} -tAc", %Q{"SELECT 1 FROM pg_database WHERE datname='#{fetch(:pg_database)}';" | grep -q 1}
       end
 
     end


### PR DESCRIPTION
The configured `pg_port` was not supplied to the `psql -c` commands, thus all commands were executed against the default port of 5432.