### PR TITLE
Fix error if local template exists: "no implicit conversion of StringIO into String"

### DIFF
--- a/lib/capistrano/postgresql/helper_methods.rb
+++ b/lib/capistrano/postgresql/helper_methods.rb
@@ -48,7 +48,7 @@ module Capistrano
           generate_database_yml_io
         else
           if File.exists?(config_file) # If there is a customized file in your rails app template directory, use it and convert any ERB
-            StringIO.new ERB.new(File.read(config_file)).result(binding)
+            StringIO.new(ERB.new(File.read(config_file)).result(binding)).string
           else # Else there's no customized file in your rails app template directory, proceed with the default.
             # Build yml file from settings
             ## We build the file line by line to avoid overwriting existing files


### PR DESCRIPTION
I ran into this problem, when I had a template in my project `config/deploy/templates/postgresql.yml.erb`.

The code further up the call stack, will run `StringIO.new()` which results in a failure:

https://github.com/capistrano-plugins/capistrano-postgresql/blob/77ae45560c409d886881bbecfc95216c071fa1b9/lib/capistrano/tasks/postgresql.rake#L126-L128

So in the case where `pg_template()` method returns a StringIO we see this error:

```
~/.rvm/gems/ruby-3.1.2/gems/sshkit-1.21.3/lib/sshkit/runners/parallel.rb:15:in `rescue in block (2 levels) in execute': 
    Exception while executing on host xxxx: no implicit conversion of StringIO into String (SSHKit::Runner::ExecuteError)
	from ~/.rvm/gems/ruby-3.1.2/gems/sshkit-1.21.3/lib/sshkit/runners/parallel.rb:11:in `block (2 levels) in execute'
~/.rvm/gems/ruby-3.1.2/gems/capistrano-postgresql-6.2.0/lib/capistrano/tasks/postgresql.rake:127:in `initialize': no implicit conversion of StringIO into String (TypeError)
	from ~/.rvm/gems/ruby-3.1.2/gems/capistrano-postgresql-6.2.0/lib/capistrano/tasks/postgresql.rake:127:in `new'
	from ~/.rvm/gems/ruby-3.1.2/gems/capistrano-postgresql-6.2.0/lib/capistrano/tasks/postgresql.rake:127:in `block (3 levels) in <top (required)>'
	from ~/.rvm/gems/ruby-3.1.2/gems/sshkit-1.21.3/lib/sshkit/backends/abstract.rb:31:in `instance_exec'
	from ~/.rvm/gems/ruby-3.1.2/gems/sshkit-1.21.3/lib/sshkit/backends/abstract.rb:31:in `run'
	from ~/.rvm/gems/ruby-3.1.2/gems/sshkit-1.21.3/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing on host xxxx: no implicit conversion of StringIO into String


Caused by:
TypeError: no implicit conversion of StringIO into String

Tasks: TOP => postgresql:generate_database_yml_archetype

```


The PR here fixes the bug. I saw no tests in the library, and also my rubocop noted a lot of issues in the file already.


With the lack of tests and lack of linting, please review carefully.