### PR TITLE
Replace deprecated `File#exists?` with `File#exist?` for ruby >= 3.2

### DIFF
--- a/lib/capistrano/postgresql/helper_methods.rb
+++ b/lib/capistrano/postgresql/helper_methods.rb
@@ -43,11 +43,11 @@ module Capistrano
         config_file = "#{fetch(:pg_templates_path)}/postgresql.yml.erb"
         if update
           raise('Regeneration of archetype database.yml need the original file to update from.') if archetype_file.nil?
-          raise('Cannot update a custom postgresql.yml.erb file.') if File.exists?(config_file) # Skip custom postgresql.yml.erb if we're updating. It's not supported
+          raise('Cannot update a custom postgresql.yml.erb file.') if File.exist?(config_file) # Skip custom postgresql.yml.erb if we're updating. It's not supported
           # Update yml file from settings
           generate_database_yml_io
         else
-          if File.exists?(config_file) # If there is a customized file in your rails app template directory, use it and convert any ERB
+          if File.exist?(config_file) # If there is a customized file in your rails app template directory, use it and convert any ERB
             StringIO.new ERB.new(File.read(config_file)).result(binding)
           else # Else there's no customized file in your rails app template directory, proceed with the default.
             # Build yml file from settings


### PR DESCRIPTION
For any projects built with a ruby version of 3.2.0 or higher, the `cap setup` command will fail with the following error: 

```
... 
      01 CREATE DATABASE
    ✔ 01 ubuntu@15.188.115.192 0.604s
00:01 postgresql:generate_database_yml_archetype
      01 mkdir -pv /home/ubuntu/projects/office_hardware_management/staging/db
      01 mkdir: created directory '/home/ubuntu/projects/office_hardware_management/staging/db'
    ✔ 01 ubuntu@15.188.115.192 0.101s
#<Thread:0x000000010968f7e0 /Users/vinnie-bp/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/sshkit-1.21.4/lib/sshkit/runners/parallel.rb:10 run> terminated with exception (report_on_exception is true):
/Users/vinnie-bp/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/sshkit-1.21.4/lib/sshkit/runners/parallel.rb:15:in `rescue in block (2 levels) in execute': Exception while executing as ubuntu@15.188.115.192: undefined method `exists?' for File:Class (SSHKit::Runner::ExecuteError)
        from /Users/vinnie-bp/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/sshkit-1.21.4/lib/sshkit/runners/parallel.rb:11:in `block (2 levels) in execute'
/Users/vinnie-bp/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/capistrano-postgresql-6.2.0/lib/capistrano/postgresql/helper_methods.rb:50:in `pg_template': undefined method `exists?' for File:Class (NoMethodError)

          if File.exists?(config_file) # If there is a customized file in your rails app template directory, use it and convert any ERB
                 ^^^^^^^^
Did you mean?  exist?
        from /Users/vinnie-bp/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/capistrano-postgresql-6.2.0/lib/capistrano/tasks/postgresql.rake:127:in `block (3 levels) in <top (required)>'
        from /Users/vinnie-bp/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/sshkit-1.21.4/lib/sshkit/backends/abstract.rb:31:in `instance_exec'
        from /Users/vinnie-bp/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/sshkit-1.21.4/lib/sshkit/backends/abstract.rb:31:in `run'
        from /Users/vinnie-bp/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/sshkit-1.21.4/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Runner::ExecuteError: Exception while executing as ubuntu@15.188.115.192: undefined method `exists?' for File:Class


Caused by:
NoMethodError: undefined method `exists?' for File:Class

Tasks: TOP => postgresql:generate_database_yml_archetype
```

The [ruby changelogs](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) refer to the deprecation of the `#exists?` method.

We can use the alias `#exist?` ([ref](https://apidock.com/ruby/File/exist%3F/class))